### PR TITLE
Fix Mullvad Netherland servers

### DIFF
--- a/openvpn/mullvad/nl_all.ovpn
+++ b/openvpn/mullvad/nl_all.ovpn
@@ -18,10 +18,9 @@ proto udp
 auth-user-pass mullvad_userpass.txt
 ca mullvad_ca.crt
 remote-random
-remote nl-ams-005.relays.mullvad.net 1194
-remote nl-ams-007.relays.mullvad.net 1194
-remote nl-ams-001.relays.mullvad.net 1194
-remote nl-ams-006.relays.mullvad.net 1194
-remote nl-ams-004.relays.mullvad.net 1194
-remote nl-ams-002.relays.mullvad.net 1194
-remote nl-ams-003.relays.mullvad.net 1194
+remote nl-ams-ovpn-001.relays.mullvad.net 1194
+remote nl-ams-ovpn-002.relays.mullvad.net 1194
+remote nl-ams-ovpn-003.relays.mullvad.net 1194
+remote nl-ams-ovpn-004.relays.mullvad.net 1194
+remote nl-ams-ovpn-005.relays.mullvad.net 1194
+remote nl-ams-ovpn-006.relays.mullvad.net 1194

--- a/openvpn/mullvad/nl_ams.ovpn
+++ b/openvpn/mullvad/nl_ams.ovpn
@@ -19,10 +19,9 @@ tun-ipv6
 script-security 2
 fast-io
 remote-random
-remote nl-ams-005.relays.mullvad.net 1300
-remote nl-ams-001.relays.mullvad.net 1300
-remote nl-ams-006.relays.mullvad.net 1300
-remote nl-ams-004.relays.mullvad.net 1300
-remote nl-ams-002.relays.mullvad.net 1300
-remote nl-ams-007.relays.mullvad.net 1300
-remote nl-ams-003.relays.mullvad.net 1300
+remote nl-ams-ovpn-001.relays.mullvad.net 1194
+remote nl-ams-ovpn-002.relays.mullvad.net 1194
+remote nl-ams-ovpn-003.relays.mullvad.net 1194
+remote nl-ams-ovpn-004.relays.mullvad.net 1194
+remote nl-ams-ovpn-005.relays.mullvad.net 1194
+remote nl-ams-ovpn-006.relays.mullvad.net 1194


### PR DESCRIPTION
The Mullvad Netherlands servers need fixing as their new addresses now correspond to the IPs listed in the [Mullvad configuration generator](https://mullvad.net/en/account/#/openvpn-config/) and [server list ](https://mullvad.net/en/servers).