### PR TITLE
Fix Privado update script sed file paths

### DIFF
--- a/openvpn/privado/updateConfigs.sh
+++ b/openvpn/privado/updateConfigs.sh
@@ -3,7 +3,7 @@
 set -e
 
 # If the script is called from elsewhere
-cd "$(dirname "$0")"
+cd "${0%/*}"
 
 # Delete everything (not this script though)
 find . ! -name '*.sh' -delete
@@ -13,13 +13,15 @@ curl -L https://privado.io/apps/ovpn_configs.zip -o privado_configs.zip &&
 	unzip -j privado_configs.zip && rm -f privado_configs.zip
 
 # Delete "tcp-scramble" files
-rm -f *.tcp-scramble.ovpn
+rm -f ./*.tcp-scramble.ovpn
 
-# Strip out ".default" from filenames
-for f in *.default.ovpn; do mv -- "$f" "${f%.default.ovpn}.ovpn"; done
-
-# Update configs with correct paths
-sed -i "s/auth-user-pass/auth-user-pass \/config\/openvpn-credentials.txt/" *.ovpn
+for f in *.default.ovpn; do
+	fn="${f%.default.ovpn}.ovpn"
+	# Strip out ".default" from filenames
+	mv -- "$f" "$fn"
+	# Update configs with correct paths
+	sed -i "s/auth-user-pass/auth-user-pass \/config\/openvpn-credentials.txt/" "$fn"
+done
 
 # Create symlink for default.ovpn using the first ams-XXX.ovpn file
 files=(ams-*.ovpn)


### PR DESCRIPTION
This fixes sed "can't read *.ovpn: No such file or directory" error when running the updateConfigs.sh script from a different directory.

<img width="1570" alt="image" src="https://github.com/user-attachments/assets/94055dc2-00bd-4622-8786-f6b2c3f809a3" />
