### PR TITLE
Added forwarded port checking in update-port.sh

### DIFF
--- a/openvpn/protonvpn/update-port.sh
+++ b/openvpn/protonvpn/update-port.sh
@@ -177,6 +177,7 @@ update_port() {
 # 80 x 45s sleep = 1 hour between checks
 check_port_loops=80
 check_port_loop_count=$check_port_loops
+check_port_retry="false"
 check_port() {
     if [[ "${ENABLE_PORT_CHECK,,}" != "true" ]]; then
         return 0
@@ -189,6 +190,7 @@ check_port() {
     result=$(curl -4 -s --fail --max-time 15 "https://portcheck.transmissionbt.com/$current_port" 2>/dev/null)
     rc=$?
     if [[ "$result" == "1" ]]; then
+        check_port_retry="false"
         #box_out "Port $current_port verified open"
         return 0
     elif [[ "$result" == "0" ]]; then
@@ -197,6 +199,12 @@ check_port() {
         log "Port check inconclusive: portcheck server unreachable (curl exit $rc)"
     else
         log "Port check inconclusive: unexpected response ('$result')"
+    fi
+    if [[ "$check_port_retry" == "true" ]]; then
+        check_port_retry="true"
+        check_port_loop_count=$check_port_loops
+    else
+        check_port_retry="false"
     fi
 }
 

--- a/openvpn/protonvpn/update-port.sh
+++ b/openvpn/protonvpn/update-port.sh
@@ -174,18 +174,19 @@ update_port() {
 # Uncomment to force enabling port checking:
 #ENABLE_PORT_CHECK="true"
 
-# 80 x 45s sleep = 1 hour between checks
-check_port_loops=80
-check_port_loop_count=$check_port_loops
 check_port_retry="false"
+check_port_last=""
 check_port() {
     if [[ "${ENABLE_PORT_CHECK,,}" != "true" ]]; then
         return 0
     fi
     [[ "$current_port" =~ ^[0-9]+$ ]] || return 0
-    check_port_loop_count=$((check_port_loop_count + 1))
-    (( check_port_loop_count >= check_port_loops )) || return 0
-    check_port_loop_count=0
+    if [[ "$current_port" != "$check_port_last" ]]; then
+        check_port_retry="false"
+    elif [[ "$check_port_retry" != "true" ]]; then
+        return 0
+    fi
+    check_port_last="$current_port"
     local result rc
     result=$(curl -4 -s --fail --max-time 15 "https://portcheck.transmissionbt.com/$current_port" 2>/dev/null)
     rc=$?
@@ -202,7 +203,6 @@ check_port() {
     fi
     if [[ "$check_port_retry" != "true" ]]; then
         check_port_retry="true"
-        check_port_loop_count=$check_port_loops
     else
         check_port_retry="false"
     fi

--- a/openvpn/protonvpn/update-port.sh
+++ b/openvpn/protonvpn/update-port.sh
@@ -13,6 +13,11 @@ new_port="unset"
 last_port="unset"
 current_port="unset"
 double_check="false"
+check_port_retry="false"
+check_port_last="unset"
+
+# Uncomment to force enabling port checking:
+#ENABLE_PORT_CHECK="true"
 
 log() { echo -e "update-port:\t$1"; }
 
@@ -171,11 +176,6 @@ update_port() {
     fi
 }
 
-# Uncomment to force enabling port checking:
-#ENABLE_PORT_CHECK="true"
-
-check_port_retry="false"
-check_port_last=""
 check_port() {
     if [[ "${ENABLE_PORT_CHECK,,}" != "true" ]]; then
         return 0

--- a/openvpn/protonvpn/update-port.sh
+++ b/openvpn/protonvpn/update-port.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 . /etc/transmission/environment-variables.sh
+ENABLE_PORT_CHECK="${ENABLE_PORT_CHECK:-false}"
 TRANSMISSION_PASSWD_FILE=/config/transmission-credentials.txt
 transmission_username=$(head -1 "${TRANSMISSION_PASSWD_FILE}")
 transmission_passwd=$(tail -1 "${TRANSMISSION_PASSWD_FILE}")
@@ -170,6 +171,29 @@ update_port() {
     fi
 }
 
+# Uncomment to force enabling port checking:
+#ENABLE_PORT_CHECK="true"
+
+# 80 x 45s sleep = 1 hour between checks
+check_port_loops=80
+check_port_loop_count=$check_port_loops
+check_port() {
+    if [[ "${ENABLE_PORT_CHECK,,}" != "true" ]]; then
+        return 0
+    fi
+    [[ "$current_port" =~ ^[0-9]+$ ]] || return 0
+    check_port_loop_count=$((check_port_loop_count + 1))
+    (( check_port_loop_count >= check_port_loops )) || return 0
+    check_port_loop_count=0
+    local result
+    result=$(curl -4 -s --max-time 15 "https://portcheck.transmissionbt.com/$current_port" 2>/dev/null)
+    if [[ "$result" == "1" ]]; then
+        #log "Port $current_port verified open"
+        return 0
+    fi
+    box_out "Port $current_port tested closed (portcheck returned '${result:-no response}')"
+}
+
 log "Waiting for healthcheck to pass before updating ports..."
 while ! /etc/scripts/healthcheck.sh; do
     log "Not healthy yet. Retrying in 5 seconds..."
@@ -203,5 +227,6 @@ set +e
 while true; do
     update_port
     set_firewall
+    check_port
     sleep 45
 done

--- a/openvpn/protonvpn/update-port.sh
+++ b/openvpn/protonvpn/update-port.sh
@@ -200,7 +200,7 @@ check_port() {
     else
         log "Port check inconclusive: unexpected response ('$result')"
     fi
-    if [[ "$check_port_retry" == "true" ]]; then
+    if [[ "$check_port_retry" != "true" ]]; then
         check_port_retry="true"
         check_port_loop_count=$check_port_loops
     else

--- a/openvpn/protonvpn/update-port.sh
+++ b/openvpn/protonvpn/update-port.sh
@@ -192,7 +192,7 @@ check_port() {
     rc=$?
     if [[ "$result" == "1" ]]; then
         check_port_retry="false"
-        #box_out "Port $current_port verified open"
+        box_out "Port $current_port verified open"
         return 0
     elif [[ "$result" == "0" ]]; then
         log "Port $current_port tested closed"

--- a/openvpn/protonvpn/update-port.sh
+++ b/openvpn/protonvpn/update-port.sh
@@ -14,7 +14,7 @@ last_port="unset"
 current_port="unset"
 double_check="false"
 check_port_retry="false"
-check_port_first_try="true"
+check_port_first_fail="true"
 check_port_last="unset"
 
 # Uncomment to force enabling port checking:
@@ -197,8 +197,8 @@ check_port() {
         return 0
     elif [[ "$result" == "0" ]]; then
         log "Port $current_port tested closed"
-        if [[ "$check_port_first_try" == "true" ]]; then
-            check_port_first_try="false"
+        if [[ "$check_port_first_fail" == "true" ]]; then
+            check_port_first_fail="false"
             local pmp_ip ext_ip
             pmp_ip=$(timeout 5 natpmpc -g 10.2.0.1 2>/dev/null | sed -nr 's/.*[Pp]ublic IP address *: *([0-9.]+).*/\1/p' | head -1)
             ext_ip=$(curl -4 -s --max-time 10 https://api.ipify.org 2>/dev/null)

--- a/openvpn/protonvpn/update-port.sh
+++ b/openvpn/protonvpn/update-port.sh
@@ -14,6 +14,7 @@ last_port="unset"
 current_port="unset"
 double_check="false"
 check_port_retry="false"
+check_port_first_try="true"
 check_port_last="unset"
 
 # Uncomment to force enabling port checking:
@@ -196,6 +197,17 @@ check_port() {
         return 0
     elif [[ "$result" == "0" ]]; then
         log "Port $current_port tested closed"
+        if [[ "$check_port_first_try" == "true" ]]; then
+            check_port_first_try="false"
+            local pmp_ip ext_ip
+            pmp_ip=$(timeout 5 natpmpc -g 10.2.0.1 2>/dev/null | sed -nr 's/.*[Pp]ublic IP address *: *([0-9.]+).*/\1/p' | head -1)
+            ext_ip=$(curl -4 -s --max-time 10 https://api.ipify.org 2>/dev/null)
+            log "natpmpc says public IP is: ${pmp_ip:-unknown}"
+            log "actual outbound IP is:     ${ext_ip:-unknown}"
+            if [[ -n "$pmp_ip" && -n "$ext_ip" && "$pmp_ip" != "$ext_ip" ]]; then
+                log "MISMATCH — port opened on $pmp_ip but traffic exits via $ext_ip"
+            fi
+        fi
     elif (( rc != 0 )); then
         log "Port check inconclusive: portcheck server unreachable (curl exit $rc)"
     else

--- a/openvpn/protonvpn/update-port.sh
+++ b/openvpn/protonvpn/update-port.sh
@@ -201,11 +201,14 @@ check_port() {
             check_port_first_fail="false"
             local pmp_ip ext_ip
             pmp_ip=$(timeout 5 natpmpc -g 10.2.0.1 2>/dev/null | sed -nr 's/.*[Pp]ublic IP address *: *([0-9.]+).*/\1/p' | head -1)
-            ext_ip=$(curl -4 -s --max-time 10 https://api.ipify.org 2>/dev/null)
-            log "natpmpc says public IP is: ${pmp_ip:-unknown}"
-            log "actual outbound IP is:     ${ext_ip:-unknown}"
-            if [[ -n "$pmp_ip" && -n "$ext_ip" && "$pmp_ip" != "$ext_ip" ]]; then
-                log "MISMATCH — port opened on $pmp_ip but traffic exits via $ext_ip"
+            ext_ip=$(curl -4 -s --fail --max-time 10 https://api.ipify.org 2>/dev/null | tr -d '[:space:]')
+            [[ "$ext_ip" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] || ext_ip=""
+            if [[ -z "$ext_ip" ]]; then
+                log "IP mismatch check skipped: could not determine outbound IP"
+            elif [[ "$pmp_ip" != "$ext_ip" ]]; then
+                log "natpmpc says public IP is: ${pmp_ip:-unknown}"
+                log "actual outbound IP is:     ${ext_ip:-unknown}"
+                log "IP MISMATCH — port opened on $pmp_ip but traffic exits via $ext_ip"
             fi
         fi
     elif (( rc != 0 )); then

--- a/openvpn/protonvpn/update-port.sh
+++ b/openvpn/protonvpn/update-port.sh
@@ -185,13 +185,19 @@ check_port() {
     check_port_loop_count=$((check_port_loop_count + 1))
     (( check_port_loop_count >= check_port_loops )) || return 0
     check_port_loop_count=0
-    local result
-    result=$(curl -4 -s --max-time 15 "https://portcheck.transmissionbt.com/$current_port" 2>/dev/null)
+    local result rc
+    result=$(curl -4 -s --fail --max-time 15 "https://portcheck.transmissionbt.com/$current_port" 2>/dev/null)
+    rc=$?
     if [[ "$result" == "1" ]]; then
-        #log "Port $current_port verified open"
+        #box_out "Port $current_port verified open"
         return 0
+    elif [[ "$result" == "0" ]]; then
+        log "Port $current_port tested closed"
+    elif (( rc != 0 )); then
+        log "Port check inconclusive: portcheck server unreachable (curl exit $rc)"
+    else
+        log "Port check inconclusive: unexpected response ('$result')"
     fi
-    box_out "Port $current_port tested closed (portcheck returned '${result:-no response}')"
 }
 
 log "Waiting for healthcheck to pass before updating ports..."


### PR DESCRIPTION
Adds an optional port check to update-port.sh, for when Transmission's built-in port checking sometimes fails to check the forwarded port correctly. Disabled by default.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section emtpy if this PR is NOT a breaking change.
-->
```txt
<placeholder>
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```txt
<placeholder>
```


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New provider (thank you!)
- [ ] Updated provider (thank you!)
- [ ] New feature (which adds functionality to a provider script/repo usage)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: ```fixes #```
- This PR is related to issue: ```relates to #```
- Link to documentation updated (if done separately): ```https://...```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->
